### PR TITLE
自动清理jsdelivr缓存

### DIFF
--- a/.github/workflows/jsdelivr.yml
+++ b/.github/workflows/jsdelivr.yml
@@ -1,0 +1,23 @@
+name: Purge Cache
+
+on: [push, workflow_dispatch]
+
+jobs:
+  speed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Purge Cache
+        run: |
+          files=$(ls $GITHUB_WORKSPACE)
+          for f in $files
+          do
+           if [[ $f == *".json" ]]; then
+            file=$f
+            url="https://purge.jsdelivr.net/gh/bushixuanqi/book-source/$file"
+            echo $url
+            curl $url
+           fi
+          done


### PR DESCRIPTION
由于jsdelivr缓存更新延迟时间很长，所以加了自动清除缓存，使其能实时更新
自动清除缓存只针对`book-source`目录下的json文件，不包括其子文件夹下的json文件